### PR TITLE
feat(readme): add section on dynamic imports and webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ require("babel-core").transform("code", {
   plugins: ["dynamic-import-webpack"]
 });
 ```
+
+### Dynamic imports and webpack
+
+Although the specification for `import()` supports a dynamic importing of modules in the browser runtime, webpack's `require.ensure()` is not dynamic and requires a hardcoded string to work correctly. For more information see [webpack's documentation](https://webpack.github.io/docs/context.html#dynamic-requires) on dynamic requires. 


### PR DESCRIPTION
- This adds a section that clarifies that this will not _really_ be a dynamic import, as well as providing a reference to _how_ to perform a "dynamic" import via webpack's `ContextModule`.
