### PR TITLE
Visit Import nodes instead of CallExpressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import template from 'babel-template';
 import syntax from 'babel-plugin-syntax-dynamic-import';
 
-const TYPE_IMPORT = 'Import';
-
 const buildImport = template(`
   (new Promise((resolve) => {
     require.ensure([], (require) => {
@@ -15,13 +13,11 @@ export default () => ({
   inherits: syntax,
 
   visitor: {
-    CallExpression(path) {
-      if (path.node.callee.type === TYPE_IMPORT) {
-        const newImport = buildImport({
-          SOURCE: path.node.arguments,
-        });
-        path.replaceWith(newImport);
-      }
+    Import(path) {
+      const newImport = buildImport({
+        SOURCE: path.parentPath.node.arguments,
+      });
+      path.parentPath.replaceWith(newImport);
     },
   },
 });


### PR DESCRIPTION
As discussed in [babel-plugin-dynamic-import-node#30](https://github.com/airbnb/babel-plugin-dynamic-import-node/pull/30)