### PR TITLE
Babel 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ node_js:
   - "10"
   - "8"
   - "6"
-  - "4"
 before_install:
   - 'nvm install-latest-npm'
-install:
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.9" ]; then nvm install --latest-npm 0.8 && npm install && nvm use "${TRAVIS_NODE_VERSION}"; else npm install; fi;'
 script:
   - 'if [ -n "${PRETEST-}" ]; then npm run pretest ; fi'
   - 'if [ -n "${POSTTEST-}" ]; then npm run posttest ; fi'

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ babel --plugins dynamic-import-webpack script.js
 ### Via Node API
 
 ```javascript
-require("babel-core").transform("code", {
+require("@babel/core").transform("code", {
   plugins: ["dynamic-import-webpack"]
 });
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "babel src --out-dir lib",
     "pretest": "npm run lint",
     "test": "npm run tests-only",
-    "tests-only": "tape --require babel-register test",
+    "tests-only": "tape --require @babel/register test",
     "lint": "eslint .",
     "prepublish": "in-publish && safe-publish-latest && npm run build || not-in-publish",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
@@ -42,17 +42,24 @@
   },
   "homepage": "https://github.com/airbnb/babel-plugin-dynamic-import-webpack#readme",
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-eslint": "^8.2.3",
-    "babel-preset-airbnb": "^2.4.0",
-    "babel-register": "^6.26.0",
+    "@babel/cli": "^7.1.2",
+    "@babel/core": "^7.1.2",
+    "@babel/register": "^7.0.0",
+    "babel-eslint": "^8.2.6",
+    "babel-preset-airbnb": "^3.0.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.12.0",
     "in-publish": "^2.0.0",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.1",
-    "tape": "^4.9.0"
+    "tape": "^4.9.1"
+  },
+  "dependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,9 @@
-export default ({ template }) => {
+import { declare } from '@babel/helper-plugin-utils';
+import syntax from '@babel/plugin-syntax-dynamic-import';
+
+export default declare(({ assertVersion, template }) => {
+  assertVersion(7);
+
   const buildImport = template(`
   (new Promise((resolve) => {
     require.ensure([], (require) => {
@@ -8,12 +13,7 @@ export default ({ template }) => {
 `);
 
   return {
-    // NOTE: Once we drop support for Babel <= v6 we should
-    // update this to import from @babel/plugin-syntax-dynamic-import.
-    // https://www.npmjs.com/package/@babel/plugin-syntax-dynamic-import
-    manipulateOptions(opts, parserOpts) {
-      parserOpts.plugins.push('dynamicImport');
-    },
+    inherits: syntax,
     visitor: {
       Import(path) {
         const newImport = buildImport({
@@ -23,4 +23,4 @@ export default ({ template }) => {
       },
     },
   };
-};
+});

--- a/test/fixtures/chained-import/expected.js
+++ b/test/fixtures/chained-import/expected.js
@@ -7,7 +7,6 @@ new Promise(resolve => {
     resolve(require('test-module-2'));
   });
 }));
-
 Promise.all([new Promise(resolve => {
   require.ensure([], require => {
     resolve(require('test-1'));

--- a/test/fixtures/dynamic-argument/expected.js
+++ b/test/fixtures/dynamic-argument/expected.js
@@ -1,5 +1,4 @@
 const MODULE = 'test-module';
-
 new Promise(resolve => {
   require.ensure([], require => {
     resolve(require(MODULE));

--- a/test/testPlugin.js
+++ b/test/testPlugin.js
@@ -1,4 +1,4 @@
-import { transform } from 'babel-core';
+import { transform } from '@babel/core';
 
 export default function testPlugin(code) {
   const result = transform(code, {


### PR DESCRIPTION
Bumps deps to Babel v7 
```
babel-cli@^6.26.0 -> @babel/cli@^7.1.2
babel-core@^6.26.3 -> @babel/core@^7.1.2
babel-register@^6.26.0 -> @babel/register@^7.0.0
babel-preset-airbnb@2.4.0  -> ^3.0.1
```
Also bumps `tape`: `^4.9.0` -> `^4.9.1`

Also updated the npm test script to use `@babel/register` and updated the readme to require `@babel/core`. 

Looks like some new lines were removed while transforming with Babel 7 🤔, so I omitted them in the expected fixtures (https://github.com/airbnb/babel-plugin-dynamic-import-webpack/pull/50/commits/d8397fd7a19032f8ac829b8567b0c6fa1b2defb2). 

Tested this by npm linking to the Babel 7 branch on babel-preset-airbnb (https://github.com/airbnb/babel-preset-airbnb/pull/37), and running tests. 