### PR TITLE
Remove dependencies on babel-template and babel-plugin-syntax-dynamic-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,5 @@
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.1",
     "tape": "^4.9.0"
-  },
-  "dependencies": {
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-template": "^6.26.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
-import template from 'babel-template';
-import syntax from 'babel-plugin-syntax-dynamic-import';
-
-const buildImport = template(`
+export default ({ template }) => {
+  const buildImport = template(`
   (new Promise((resolve) => {
     require.ensure([], (require) => {
       resolve(require(SOURCE));
@@ -9,15 +7,20 @@ const buildImport = template(`
   }))
 `);
 
-export default () => ({
-  inherits: syntax,
-
-  visitor: {
-    Import(path) {
-      const newImport = buildImport({
-        SOURCE: path.parentPath.node.arguments,
-      });
-      path.parentPath.replaceWith(newImport);
+  return {
+    // NOTE: Once we drop support for Babel <= v6 we should
+    // update this to import from @babel/plugin-syntax-dynamic-import.
+    // https://www.npmjs.com/package/@babel/plugin-syntax-dynamic-import
+    manipulateOptions(opts, parserOpts) {
+      parserOpts.plugins.push('dynamicImport');
     },
-  },
-});
+    visitor: {
+      Import(path) {
+        const newImport = buildImport({
+          SOURCE: path.parentPath.node.arguments,
+        });
+        path.parentPath.replaceWith(newImport);
+      },
+    },
+  };
+};


### PR DESCRIPTION
As mentioned in: https://github.com/airbnb/babel-plugin-dynamic-import-webpack/pull/50#discussion_r222883244, we can configure this plugin in a way that might work with both Babel 6 and 7. 

This change use `template` provided by the babel plugin API instead of importing from `babel-template` and configures the dynamic import syntax options directly instead of using the external plugin.

cc. @ljharb 

